### PR TITLE
Added support and basic test for template strings

### DIFF
--- a/lib/pretty-js.js
+++ b/lib/pretty-js.js
@@ -1438,6 +1438,17 @@
         result.addSpace();
     }
 
+    /**
+     * Processes a template string and does not process quotes.
+     *
+     * @param {prettyJs~Result} result
+     * @param {complexionJs~ComplexionJsToken} token
+     */
+    function tokenTemplateString(result, token) {
+        result.addFragment('STRING', token.content);
+        result.addSpace();
+    }
+
     // Initialize a new tokenizer with the default options
     tokenizer = new Complexion();
     complexionJs(tokenizer);
@@ -1490,6 +1501,7 @@
         SHEBANG: tokenCopyAndNewline,
         SINGLE_LINE_COMMENT: tokenSingleLineComment,
         STRING_LITERAL: tokenString,
+        TEMPLATE_STRING: tokenTemplateString,
         WHITESPACE: tokenSkip  // Other rules manage all whitespace
     };
 

--- a/test.js
+++ b/test.js
@@ -1,0 +1,1 @@
+`hello ${person}`;

--- a/tests/fixtures/string-interpolation.json
+++ b/tests/fixtures/string-interpolation.json
@@ -1,0 +1,4 @@
+{
+    "input": "`this is a ${test}`",
+    "output": "`this is a ${test}`"
+}


### PR DESCRIPTION
Requires tests-always-included/complexion-js#1 to work correctly. Supports work in #12.

I am open to adding more tests for this behavior. In my testing on a medium ES6 codebase, I haven't noticed any issues and I'm not sure what other test cases we would need.