### PR TITLE
Add noNewlineBetweenVar option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ $*
 .settings*
 .metadata/
 nbproject/
+/Session.vim
+.*.sw?
 
 # Generated
 /node_modules/

--- a/README.md
+++ b/README.md
@@ -183,6 +183,13 @@ Enabling this option removes the space that would appear in `switch (`.
 Defaults to false.
 
 
+### noNewlineBetweenVar (boolean)
+
+Enable this option to disable the double newlines between var statements. The last var in a group will still be followed by a blank line.
+
+Defaults to false.
+
+
 ### noSpaceWithIncDec (boolean)
 
 Enable this option to remove the space between an identifier and the ++ or --.

--- a/bin/pretty-js.js
+++ b/bin/pretty-js.js
@@ -31,6 +31,7 @@ options = {
     inPlace: false,
     jslint: false,
     newline: "\n",
+    noNewlineBetweenVar: false, 
     noSpaceAfterIf: false,
     noSpaceAfterFor: false,
     noSpaceAfterFunction: false,
@@ -182,6 +183,11 @@ parser.addOption(null, 'no-space-after', 'Prevent the beautifier from adding a s
 parser.addOption(null, 'no-space-with-inc-dec', 'Prevent the addition of a space between an identifier and ++ or --.')
     .action(function () {
         options.noSpaceWithIncDec = true;
+    });
+
+parser.addOption(null, 'no-newline-between-var', 'Prevent the addition of a newline between adjacent var statements. A newline will still be added at the end of a run of var statements.')
+    .action(function () {
+        options.noNewlineBetweenVar = true;
     });
 
 parser.addOption('q', 'quote-properties', 'How should object literals list their properties?  "add" will always add quotes, "remove" removes unnecessary quoting and "preserve" keeps properties as-is.  For JSON you want "add" in order to correct common quoting errors.  Default is "remove".')

--- a/lib/pretty-js.js
+++ b/lib/pretty-js.js
@@ -54,11 +54,15 @@
      *
      * @property {Array.<prettyJs~resultBit>} contexts Context and indentation
      * @property {Array.<prettyJs~resultBit>} fragments Formatted output
+     * @property {Boolean.prettyJs~onNewLine} between newline and first non-blank
+     * @property {Object.prettyJs~firstFragment} the first fragment on the most recent line
      * @property {prettyJs~options} options
      */
     function Result(options) {
         this.contexts = [];
         this.fragments = [];
+        this.onNewLine = true;
+        this.firstFragment = null;
         this.options = options;
     }
 
@@ -113,6 +117,18 @@
             code: code,
             content: content
         });
+
+        if (code === 'NEWLINE') {
+            this.onNewLine = true;
+        } else if (this.onNewLine && code !== 'SPACE' && code !== 'INDENT') {
+            this.onNewLine = false;
+            // Stash the first non-blank fragment of each line so we can
+            // detect runs of similar lines
+            this.firstFragment = {
+                code: code,
+                content: content
+            };
+        }
     };
 
     /**
@@ -148,10 +164,7 @@
      * @param {complexionJs~ComplexionJsToken} token
      */
     Result.prototype.addToken = function (token) {
-        this.fragments.push({
-            code: token.type,
-            content: token.content
-        });
+        this.addFragment(token.type, token.content);
     };
 
     /**
@@ -246,6 +259,19 @@
             }
         }
 
+        return null;
+    };
+
+    /**
+     * Returns the content of the first non-blank token on the previous line
+     * or null if there is no previous line.
+     *
+     * @return {string}
+     */
+    Result.prototype.getPreviousLineFragment = function () {
+        if (this.firstFragment) {
+            return this.firstFragment.content;
+        }
         return null;
     };
 
@@ -768,6 +794,10 @@
      * @param {complexionJs~ComplexionJsToken} token
      */
     function tokenKeywordVar(result, token) {
+        if (result.options.noNewlineBetweenVar && result.getPreviousLineFragment() === 'var') {
+            result.removeWhitespace();
+            result.addNewline();
+        }
         tokenCopyAndSpace(result, token);
         result.addContext('VAR');
     }

--- a/tests/bin-pretty-js.spec.js
+++ b/tests/bin-pretty-js.spec.js
@@ -155,6 +155,10 @@
             argumentRunner('', 'noSpaceWithIncDec: false');
             argumentRunner('--no-space-with-inc-dec', 'noSpaceWithIncDec: true');
         });
+        describe('noNewlineBetweenVar', function () {
+            argumentRunner('', 'noNewlineBetweenVar: false');
+            argumentRunner('--no-newline-between-var', 'noNewlineBetweenVar: true');
+        });
         describe('newline', function () {
             argumentRunner('', 'newline: \'\\n\'');
             argumentRunner('--newline "crlf"', 'newline: \'\\r\\n\'');

--- a/tests/options.spec.js
+++ b/tests/options.spec.js
@@ -190,6 +190,16 @@
                 })).toEqual('a++;\n--b');
             });
         });
+        describe('noNewlineBetweenVar', function () {
+            it('adds an extra newline by default', function () {
+                expect(prettyJs('var a; var b; var c;')).toEqual('var a;\n\nvar b;\n\nvar c;');
+            });
+            it('removes extra newlines', function () {
+                expect(prettyJs('var a; var b; var c;', {
+                    noNewlineBetweenVar: true
+                })).toEqual('var a;\nvar b;\nvar c;');
+            });
+        });
         describe('quoteProperties', function () {
             it('can unquote properties', function () {
                 expect(prettyJs("{'a':1,\"b\":2}", {


### PR DESCRIPTION
Hi there,

Thanks for your excellent code!

I tend to have runs of var statements so it's useful for me to be able to suppress the blank lines between them. I've added a new option to do that: noNewlineBetweenVar (and a corresponding command switch "no-newline-between-var").

I hope it's OK.

Thanks!